### PR TITLE
[FIX] oca_dependencies.txt: Clean file

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,9 +1,0 @@
-OCA_project-service https://github.com/it-projects-llc/project
-OCA_server-tools https://github.com/it-projects-llc/server-tools
-OCA_web https://github.com/it-projects-llc/web
-OCA_website https://github.com/OCA/website
-access-addons https://github.com/it-projects-llc/access-addons
-mail-addons https://github.com/it-projects-llc/mail-addons
-website-addons https://github.com/it-projects-llc/website-addons
-l10n-addons https://github.com/it-projects-llc/l10n-addons
-hr


### PR DESCRIPTION
This is a forked repository containing addons, whose file
`oca_dependencies.txt` points to:
- Repos on the original organization
- Repos from the OCA but renamed, with causes them to be duplicated when
  we also use them (e.g. `OCA_server-tools`)
- Repos that we don't need. For now, the only module we're using is
  `base_groupby_extra`, which doesn't require any extra dependency

Because of the above, the file is left empty.